### PR TITLE
fix: pytest-bdd required for normal runs (ie non dev/test), adding to…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ python-multipart==0.0.20
 rethinkdb==2.4.10.post1
 uvicorn[standard]==0.23.2
 altcha==0.1.9
+pytest-bdd==7.3.0


### PR DESCRIPTION
… requirements.txt


Traceback:
```
/opt/conda/envs/nerdd_backend/lib/python3.12/site-packages/hydra/_internal/defaults_list.py:251: UserWarning: In 'development': Defaults list is missing `_self_`. See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/default_composition_order for more information
  warnings.warn(msg, UserWarning)
[2025-06-23 13:24:37,741][__main__][INFO] - Starting server with the following configuration:
channel:
  name: memory
db:
  name: memory
host: 0.0.0.0
port: 8000
root_path: null
quota_anonymous: 1000000
challenge_difficulty: 1000
challenge_expiration_seconds: 3600
page_size_molecular_property_prediction: 5
page_size_atom_property_prediction: 3
page_size_derivative_property_prediction: 2
media_root: ./media
mock_infra: true
output_formats:
- sdf
- csv
Error executing job with overrides: []
Traceback (most recent call last):
  File "/opt/conda/envs/nerdd_backend/lib/python3.12/site-packages/nerdd_link/utils/async_to_sync.py", line 24, in wrapper
    return loop.run_until_complete(func(*args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/nerdd_backend/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/app/nerdd_backend/main.py", line 190, in main
    app = await create_app(cfg)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/app/nerdd_backend/main.py", line 89, in create_app
    from nerdd_module.tests import MolWeightModel
  File "/opt/conda/envs/nerdd_backend/lib/python3.12/site-packages/nerdd_module/tests/__init__.py", line 1, in <module>
    from .checks import *
  File "/opt/conda/envs/nerdd_backend/lib/python3.12/site-packages/nerdd_module/tests/checks.py", line 4, in <module>
    from pytest_bdd import parsers, then
ModuleNotFoundError: No module named 'pytest_bdd'
Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```